### PR TITLE
Enable custom HDR luminance via INI and env var

### DIFF
--- a/source/maindll/FFFrameInterpolator.cpp
+++ b/source/maindll/FFFrameInterpolator.cpp
@@ -7,12 +7,19 @@
 bool g_EnableDebugOverlay = false;
 bool g_EnableDebugTearLines = false;
 bool g_EnableInterpolatedFramesOnly = false;
+bool g_EnableHDRLuminanceOverride = false;
+float g_HDRLuminanceMin = 0.0001f;
+float g_HDRLuminanceMax = 1000.0000f;
+
 
 extern "C" void __declspec(dllexport) RefreshGlobalConfiguration()
 {
 	g_EnableDebugOverlay = Util::GetSetting(L"EnableDebugOverlay", false);
 	g_EnableDebugTearLines = Util::GetSetting(L"EnableDebugTearLines", false);
 	g_EnableInterpolatedFramesOnly = Util::GetSetting(L"EnableInterpolatedFramesOnly", false);
+	g_EnableHDRLuminanceOverride = Util::GetSetting(L"EnableHDRLuminanceOverride", false);
+	g_HDRLuminanceMin = Util::GetSetting(L"HDRLuminanceMin", g_HDRLuminanceMin);
+	g_HDRLuminanceMax = Util::GetSetting(L"HDRLuminanceMax", g_HDRLuminanceMax);
 }
 
 FFFrameInterpolator::FFFrameInterpolator(uint32_t OutputWidth, uint32_t OutputHeight)
@@ -208,6 +215,25 @@ void FFFrameInterpolator::QueryHDRLuminanceRange(NGXInstanceParameters *NGXParam
 
 	if (m_HDRLuminanceRangeSet)
 		return;
+
+	if (g_EnableHDRLuminanceOverride)
+	{
+		if (g_HDRLuminanceMin != m_HDRLuminanceMin)
+		{
+			m_HDRLuminanceMin = g_HDRLuminanceMin;
+			spdlog::info("Overriding HDR luminance min to {} nits", g_HDRLuminanceMin);
+		}
+
+		if (g_HDRLuminanceMax != m_HDRLuminanceMax)
+		{
+			m_HDRLuminanceMax = g_HDRLuminanceMax;
+			spdlog::info("Overriding HDR luminance max to {} nits", g_HDRLuminanceMax);
+		}
+
+		m_HDRLuminanceRange = { m_HDRLuminanceMin, m_HDRLuminanceMax };
+		m_HDRLuminanceRangeSet = true;
+		return;
+	}
 
 	// Microsoft DirectX 12 HDR sample
 	// https://github.com/microsoft/DirectX-Graphics-Samples/blob/b5f92e2251ee83db4d4c795b3cba5d470c52eaf8/Samples/Desktop/D3D12HDR/src/D3D12HDR.cpp#L1064

--- a/source/maindll/FFFrameInterpolator.h
+++ b/source/maindll/FFFrameInterpolator.h
@@ -25,8 +25,11 @@ private:
 	const uint32_t m_SwapchainWidth; // Final image presented to the screen dimensions
 	const uint32_t m_SwapchainHeight;
 
-	FfxFloatCoords2D m_HDRLuminanceRange = { 0.0001f, 1000.0f };
 	bool m_HDRLuminanceRangeSet = false;
+	float m_HDRLuminanceMin = 0.0001f;
+	float m_HDRLuminanceMax = 1000.0000f;
+	FfxFloatCoords2D m_HDRLuminanceRange = { m_HDRLuminanceMin, m_HDRLuminanceMax };
+	
 
 	// Transient
 	uint32_t m_PreUpscaleRenderWidth = 0; // GBuffer dimensions

--- a/source/maindll/Util.cpp
+++ b/source/maindll/Util.cpp
@@ -66,4 +66,32 @@ namespace Util
 		const static auto iniPath = GetThisDllPath() + L"\\dlssg_to_fsr3.ini";
 		return GetPrivateProfileIntW(L"Debug", Key, DefaultValue, iniPath.c_str()) != 0;
 	}
+
+	float GetSetting(const wchar_t *Key, float DefaultValue)
+	{
+		wchar_t envKey[256];
+		swprintf_s(envKey, L"DLSSGTOFSR3_%s", Key);
+
+		wchar_t envValue[64];
+		if (GetEnvironmentVariableW(envKey, envValue, std::size(envValue)) > 0)
+		{
+			wchar_t* endPtr;
+			float result = wcstof(envValue, &endPtr);
+			if (endPtr != envValue)
+				return result;
+		}
+
+		const static auto iniPath = GetThisDllPath() + L"\\dlssg_to_fsr3.ini";
+		
+		wchar_t iniValue[64];
+		if (GetPrivateProfileStringW(L"Debug", Key, nullptr, iniValue, std::size(iniValue), iniPath.c_str()) > 0)
+		{
+			wchar_t* endPtr;
+			float result = wcstof(iniValue, &endPtr);
+			if (endPtr != iniValue)
+				return result;
+		}
+
+		return DefaultValue;
+	}
 }

--- a/source/maindll/Util.h
+++ b/source/maindll/Util.h
@@ -4,4 +4,5 @@ namespace Util
 {
 	void InitializeLog();
 	bool GetSetting(const wchar_t *Key, bool DefaultValue);
+	float GetSetting(const wchar_t *Key, float DefaultValue);
 }


### PR DESCRIPTION
This enables the user to manually specify min/max HDR luminance settings instead of what's returned from DXGI query or the hardcoded default values.

Adds the following as environment variables and INI settings:
`EnableHDRLuminanceOverride (bool)`
`HDRLuminanceMin (float)`
`HDRLuminanceMax (float)`

Also adds an overload for `Util::GetSetting` which returns a float value to read into `HDRLuminanceMin` and `HDRLuminanceMax`.

`FFFrameInterpolator::QueryHDRLuminanceRange` is modified to check if the user has overridden the default hardcoded values via env var or INI setting and prefers to use those values first if `EnableHDRLuminanceOverride` is true and a custom value has been provided.

An example of the INI configuration file would look like this:
```ini
;
; Note: this is an optional file for dlssg_to_fsr3. Normal users can safely ignore or delete this INI.
;
; 
; FSR 3 developer debug options
;

[Debug]
EnableDebugOverlay=0
EnableDebugTearLines=0
EnableInterpolatedFramesOnly=0
EnableHDRLuminanceOverride=1
HDRLuminanceMin=0.5000
HDRLuminanceMax=1450.0
```

It didn't occur to me to commit an updated INI file example along with this, but I can do that if you'd like to merge this in. I've tested it on a few games and it appears to be working correctly.